### PR TITLE
Don't mutate headers

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -91,7 +91,7 @@ export class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   ) {
     super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
-    this.headers = headers
+    this.headers = { ...headers }
     this.schema = schema
   }
 


### PR DESCRIPTION
When building several queries using a single `PostgrestClient` instance, calling `single` will break subsequent requests since the headers object it mutates is currently shared across all queries. This PR changes the behaviour so the query builder always receives a fresh headers object that is safe to mutate.